### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,9 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ "8", "11", "16" ]
+        java: [ "8", "11", "16", "17-ea" ]
         os: [ "ubuntu-latest" ]
+        distro: [ "zulu", "temurin" ]
     # Only run on PRs if the source branch is on someone else's repo
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     runs-on: "${{ matrix.os }}"
@@ -17,7 +18,7 @@ jobs:
       - name: "setup jdk ${{ matrix.java }}"
         uses: "actions/setup-java@v2"
         with:
-          distribution: "adopt"
+          distribution: "${{ matrix.distro }}"
           java-version: "${{ matrix.java }}"
       - name: "build"
         run: "./gradlew build"


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Also added JDK 17-ea as it's the new LTS version of Java.