### PR TITLE
Resource Support and Improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "net.kyori"
-version = "1.3.1-SNAPSHOT"
+version = "1.3.1"
 description = "Gradle plugin for performing source code token replacements in Java, Kotlin, Scala, and Groovy based projects"
 
 repositories {

--- a/src/main/java/net/kyori/blossom/Blossom.java
+++ b/src/main/java/net/kyori/blossom/Blossom.java
@@ -79,8 +79,8 @@ public final class Blossom implements ProjectPlugin {
   }
 
   private void setupSourceReplacementTasks() {
-    final JavaPluginExtension javaPluginConvention = (JavaPluginExtension) this.project.getExtensions().getByName("java");
-    final SourceSet mainSourceSet = javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+    final JavaPluginExtension javaPluginExtension = (JavaPluginExtension) this.project.getExtensions().getByName("java");
+    final SourceSet mainSourceSet = javaPluginExtension.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 
     BuiltInSourceReplacementTasks.setupResources(this, mainSourceSet);
     BuiltInSourceReplacementTasks.setupJava(this, mainSourceSet);

--- a/src/main/java/net/kyori/blossom/task/BuiltInSourceReplacementTasks.java
+++ b/src/main/java/net/kyori/blossom/task/BuiltInSourceReplacementTasks.java
@@ -23,9 +23,7 @@ package net.kyori.blossom.task;
 
 import net.kyori.blossom.Blossom;
 import org.gradle.api.internal.plugins.DslObject;
-import org.gradle.api.tasks.GroovySourceSet;
-import org.gradle.api.tasks.ScalaSourceSet;
-import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.*;
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet;
 
 /**
@@ -73,5 +71,15 @@ public interface BuiltInSourceReplacementTasks {
   static void setupKotlin(final Blossom blossom, final SourceSet mainSourceSet) {
     final KotlinSourceSet set = (KotlinSourceSet) new DslObject(mainSourceSet).getConvention().getPlugins().get("kotlin");
     blossom.setupSourceReplacementTask("blossomSourceReplacementKotlin", set.getKotlin(), "sources/kotlin/", mainSourceSet.getCompileTaskName("kotlin"));
+  }
+
+  /**
+   * Setup the default Resources source replacement task
+   *
+   * @param blossom       blossom instance
+   * @param mainSourceSet source set
+   */
+  static void setupResources(final Blossom blossom, final SourceSet mainSourceSet){
+    blossom.setupSourceReplacementTask("blossomSourceReplacementResources", mainSourceSet.getResources(), "sources/resources/", mainSourceSet.getProcessResourcesTaskName());
   }
 }


### PR DESCRIPTION
* Now resources are supported
* Added extra check to the kotlin compile task to avoid unwanted issues (such as cast issues or trying to access properties that doesn't exist)
* Updated version (according to the gradle docs SNAPSHOTS are not supported)
* Updated JavaPluginConvention to JavaPluginExtension (JavaPluginConvention is deprecated)