### PR TITLE
Fix included files

### DIFF
--- a/src/test/java/net/kyori/blossom/IncludedMacrosTest.java
+++ b/src/test/java/net/kyori/blossom/IncludedMacrosTest.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of blossom, licensed under the GNU Lesser General Public License.
+ *
+ * Copyright (c) 2023 KyoriPowered
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package net.kyori.blossom;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import net.kyori.blossom.test.BlossomDisplayNameGeneration;
+import net.kyori.blossom.test.BlossomFunctionalTest;
+import net.kyori.blossom.test.SettingsFactory;
+import net.kyori.mammoth.test.TestContext;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayNameGeneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Disabled
+@DisplayNameGeneration(BlossomDisplayNameGeneration.class)
+class IncludedMacrosTest {
+  @BlossomFunctionalTest
+  void testIncludedMacros(final TestContext ctx) throws IOException {
+    SettingsFactory.writeSettings(ctx, "includedMacros");
+    ctx.copyInput("build.gradle");
+    ctx.copyInput("test.properties.peb", "src/main/resource-templates/test.properties.peb");
+    ctx.copyInput("macros.peb", "src/main/resource-macros/macros.peb");
+
+    final BuildResult result = ctx.build("assemble"); // build a jar
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":generateResourceTemplates").getOutcome());
+
+    final var destPath = ctx.outputDirectory().resolve("build/libs/includedMacros.jar");
+    assertTrue(Files.isRegularFile(destPath), "The expected jar did not exist");
+
+    try (final var jar = new JarFile(destPath.toFile())) {
+      final JarEntry entry = jar.getJarEntry("test.properties");
+      assertNotNull(entry, "no test.properties in jar");
+      final Properties props = new Properties();
+      try (final InputStream is = jar.getInputStream(entry)) {
+        props.load(is);
+      }
+
+      assertEquals("abc123 abc123 abc123", props.getProperty("value"));
+    }
+  }
+}

--- a/src/test/java/net/kyori/blossom/IncludedMacrosTest.java
+++ b/src/test/java/net/kyori/blossom/IncludedMacrosTest.java
@@ -23,6 +23,7 @@ package net.kyori.blossom;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -45,7 +46,9 @@ class IncludedMacrosTest {
     SettingsFactory.writeSettings(ctx, "includedMacros");
     ctx.copyInput("build.gradle");
     ctx.copyInput("test.properties.peb", "src/main/resource-templates/test.properties.peb");
+    // test import with and without .peb extension specified
     ctx.copyInput("macros.peb", "src/main/resource-macros/macros.peb");
+    ctx.copyInput("macros1.peb", "src/main/resource-macros/macros1.peb");
 
     final BuildResult result = ctx.build("assemble"); // build a jar
 
@@ -62,7 +65,9 @@ class IncludedMacrosTest {
         props.load(is);
       }
 
-      assertEquals("abc123 abc123 abc123", props.getProperty("value"));
+      final String expected = "abc123 abc123 abc123";
+      assertEquals(expected, props.getProperty("value"));
+      assertEquals(expected.toUpperCase(Locale.ROOT), props.getProperty("valueUpper"));
     }
   }
 }

--- a/src/test/java/net/kyori/blossom/IncludedMacrosTest.java
+++ b/src/test/java/net/kyori/blossom/IncludedMacrosTest.java
@@ -32,14 +32,12 @@ import net.kyori.blossom.test.SettingsFactory;
 import net.kyori.mammoth.test.TestContext;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGeneration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled
 @DisplayNameGeneration(BlossomDisplayNameGeneration.class)
 class IncludedMacrosTest {
   @BlossomFunctionalTest

--- a/src/test/resources/net/kyori/blossom/includedMacros/in/build.gradle
+++ b/src/test/resources/net/kyori/blossom/includedMacros/in/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'java'
+  id 'net.kyori.blossom'
+}
+
+sourceSets {
+  main {
+    blossom {
+      resources {
+        property('property', 'abc123')
+        include('src/main/resource-macros')
+      }
+    }
+  }
+}

--- a/src/test/resources/net/kyori/blossom/includedMacros/in/macros.peb
+++ b/src/test/resources/net/kyori/blossom/includedMacros/in/macros.peb
@@ -1,0 +1,3 @@
+{% macro hello(value) %}
+{{ value }} {{ value }} {{ value }}
+{% endmacro %}

--- a/src/test/resources/net/kyori/blossom/includedMacros/in/macros1.peb
+++ b/src/test/resources/net/kyori/blossom/includedMacros/in/macros1.peb
@@ -1,0 +1,3 @@
+{% macro helloUpper(value) %}
+{{ value | upper }} {{ value | upper  }} {{ value | upper  }}
+{% endmacro %}

--- a/src/test/resources/net/kyori/blossom/includedMacros/in/test.properties.peb
+++ b/src/test/resources/net/kyori/blossom/includedMacros/in/test.properties.peb
@@ -1,0 +1,2 @@
+{% import "macros.peb" %}
+value={{ hello(property) }}

--- a/src/test/resources/net/kyori/blossom/includedMacros/in/test.properties.peb
+++ b/src/test/resources/net/kyori/blossom/includedMacros/in/test.properties.peb
@@ -1,2 +1,5 @@
 {% import "macros.peb" %}
+{% import "macros1" %}
 value={{ hello(property) }}
+
+valueUpper={{ helloUpper(property) }}

--- a/src/workerClasspath/java/net/kyori/blossom/internal/worker/MultiDirectoryLoader.java
+++ b/src/workerClasspath/java/net/kyori/blossom/internal/worker/MultiDirectoryLoader.java
@@ -60,7 +60,7 @@ final class MultiDirectoryLoader implements Loader<String> {
       final Path file = path.resolve(templateName);
       if (Files.isRegularFile(file)
         // guard against escaping the directory
-        && path.relativize(file).toString().equals(templateName)) {
+        && file.toAbsolutePath().startsWith(path.toAbsolutePath())) {
         return file;
       }
     }

--- a/src/workerClasspath/java/net/kyori/blossom/internal/worker/MultiDirectoryLoader.java
+++ b/src/workerClasspath/java/net/kyori/blossom/internal/worker/MultiDirectoryLoader.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of blossom, licensed under the GNU Lesser General Public License.
+ *
+ * Copyright (c) 2023 KyoriPowered
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package net.kyori.blossom.internal.worker;
+
+import io.pebbletemplates.pebble.error.LoaderException;
+import io.pebbletemplates.pebble.loader.Loader;
+import io.pebbletemplates.pebble.utils.PathUtils;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.Nullable;
+
+final class MultiDirectoryLoader implements Loader<String> {
+  private final List<Path> directories;
+  private final Charset charset;
+
+  MultiDirectoryLoader(final List<Path> directories, final Charset charset) {
+    this.directories = List.copyOf(directories);
+    this.charset = charset;
+  }
+
+  @Override
+  public Reader getReader(final String templateName) {
+    final Path file = this.findFile(templateName);
+    if (file != null) {
+      try {
+        return Files.newBufferedReader(file, this.charset);
+      } catch (final IOException ex) {
+        throw new LoaderException(ex, "Could not load template \"" + templateName + "\" from file \"" + file + "\"");
+      }
+    }
+    throw new LoaderException(null, "Could not find template \"" + templateName + "\" in any of: " + this.directories.stream().map(Path::toString).collect(Collectors.joining("; ")));
+  }
+
+  private @Nullable Path findFile(final String templateName) {
+    for (final Path path : this.directories) {
+      final Path file = path.resolve(templateName);
+      if (Files.isRegularFile(file)
+        // guard against escaping the directory
+        && path.relativize(file).toString().equals(templateName)) {
+        return file;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public void setSuffix(final String suffix) {
+    throw new UnsupportedOperationException("Not used by Blossom");
+  }
+
+  @Override
+  public void setPrefix(final String prefix) {
+    throw new UnsupportedOperationException("Not used by Blossom");
+  }
+
+  @Override
+  public void setCharset(final String charset) {
+    throw new UnsupportedOperationException("Not used by Blossom");
+  }
+
+  @Override
+  public String resolveRelativePath(final String relativePath, final String anchorPath) {
+    return PathUtils.resolveRelativePath(relativePath, anchorPath, File.separatorChar);
+  }
+
+  @Override
+  public String createCacheKey(final String templateName) {
+    return templateName;
+  }
+
+  @Override
+  public boolean resourceExists(final String templateName) {
+    final Path path = this.findFile(templateName);
+    return path != null && Files.isRegularFile(path);
+  }
+}

--- a/src/workerClasspath/java/net/kyori/blossom/internal/worker/MultiDirectoryLoader.java
+++ b/src/workerClasspath/java/net/kyori/blossom/internal/worker/MultiDirectoryLoader.java
@@ -57,12 +57,25 @@ final class MultiDirectoryLoader implements Loader<String> {
 
   private @Nullable Path findFile(final String templateName) {
     for (final Path path : this.directories) {
-      final Path file = path.resolve(templateName);
-      if (Files.isRegularFile(file)
-        // guard against escaping the directory
-        && file.toAbsolutePath().startsWith(path.toAbsolutePath())) {
+      @Nullable Path file = findFileIn(templateName, path);
+
+      if (file == null && !templateName.endsWith(".peb")) {
+        file = findFileIn(templateName + ".peb", path);
+      }
+
+      if (file != null) {
         return file;
       }
+    }
+    return null;
+  }
+
+  private static @Nullable Path findFileIn(final String templateName, final Path path) {
+    final Path file = path.resolve(templateName);
+    if (Files.isRegularFile(file)
+      // guard against escaping the directory
+      && file.toAbsolutePath().startsWith(path.toAbsolutePath())) {
+      return file;
     }
     return null;
   }


### PR DESCRIPTION
Fixes included files and adds a test with an imported macro.

The `MultiDirectoryLoader` treats the source/included directories as if they were merged for resolving macros.

Questions:
- Do we want to have an error when there are multiple files with the same relative path?
- Is this todo in `GenerateWorkerInvokerImpl` resolved by these changes
```
    // By default, resolves FS paths
    // todo: restrict inputs to inputs and includes
```
- Do we want to automatically search for `${templateName}.peb` if `templateName` can't be found in a directory? The Pebble docs show imports being used without a `.peb` extension.

